### PR TITLE
add merkle distributer to COMP style gov token factory.

### DIFF
--- a/COMP/GovernanceFactory.sol
+++ b/COMP/GovernanceFactory.sol
@@ -165,6 +165,33 @@ library SafeMath {
     }
 }
 
+library MerkleProof {
+    /**
+     * @dev Returns true if a `leaf` can be proved to be a part of a Merkle tree
+     * defined by `root`. For this, a `proof` must be provided, containing
+     * sibling hashes on the branch from the leaf to the root of the tree. Each
+     * pair of leaves and each pair of pre-images are assumed to be sorted.
+     */
+    function verify(bytes32[] memory proof, bytes32 root, bytes32 leaf) internal pure returns (bool) {
+        bytes32 computedHash = leaf;
+
+        for (uint256 i = 0; i < proof.length; i++) {
+            bytes32 proofElement = proof[i];
+
+            if (computedHash <= proofElement) {
+                // Hash(current computed hash + current element of the proof)
+                computedHash = keccak256(abi.encodePacked(computedHash, proofElement));
+            } else {
+                // Hash(current element of the proof + current computed hash)
+                computedHash = keccak256(abi.encodePacked(proofElement, computedHash));
+            }
+        }
+
+        // Check if the computed hash (root) is equal to the provided root
+        return computedHash == root;
+    }
+}
+
 /// @notice Based on Compound Governance.
 contract Timelock {
     using SafeMath for uint;
@@ -183,7 +210,7 @@ contract Timelock {
     address public admin;
     address public pendingAdmin;
     uint public delay;
-    
+
     /// @notice Internally tracks clone deployment under eip-1167 proxy pattern
     bool private initialized;
 
@@ -590,7 +617,7 @@ contract GovernorAlpha {
 
     /// @notice The number of votes required in order for a voter to become a proposer
     uint public proposalThreshold;
-    
+
     /// @notice The duration of voting on a proposal, in blocks
     uint public votingPeriod;
 
@@ -611,7 +638,7 @@ contract GovernorAlpha {
 
     /// @notice The total number of proposals
     uint public proposalCount;
-    
+
     /// @notice Internally tracks clone deployment under eip-1167 proxy pattern
     bool private initialized;
 
@@ -919,6 +946,137 @@ interface CompInterface {
     function getPriorVotes(address account, uint blockNumber) external view returns (uint96);
 }
 
+// Allows anyone to claim a token if they exist in a merkle root.
+interface IMerkleDistributor {
+    // Returns the address of the token distributed by this contract.
+    function token() external view returns (address);
+    // Returns the merkle root of the merkle tree containing account balances available to claim.
+    function merkleRoot() external view returns (bytes32);
+    // Returns true if the index has been marked claimed.
+    function isClaimed(uint256 index) external view returns (bool);
+    // Claim the given amount of the token to the given address. Reverts if the inputs are invalid.
+    function claim(uint256 index, address account, uint256 amount, bytes32[] calldata merkleProof) external;
+
+    // This event is triggered whenever a call to #claim succeeds.
+    event Claimed(uint256 index, address account, uint256 amount);
+}
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP. Does not include
+ * the optional functions; to access them see {ERC20Detailed}.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * IMPORTANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+contract MerkleDistributor is IMerkleDistributor {
+    address public immutable override token;
+    bytes32 public immutable override merkleRoot;
+
+    // This is a packed array of booleans.
+    mapping(uint256 => uint256) private claimedBitMap;
+
+    constructor(address token_, bytes32 merkleRoot_) public {
+        token = token_;
+        merkleRoot = merkleRoot_;
+    }
+
+    function isClaimed(uint256 index) public view override returns (bool) {
+        uint256 claimedWordIndex = index / 256;
+        uint256 claimedBitIndex = index % 256;
+        uint256 claimedWord = claimedBitMap[claimedWordIndex];
+        uint256 mask = (1 << claimedBitIndex);
+        return claimedWord & mask == mask;
+    }
+
+    function _setClaimed(uint256 index) private {
+        uint256 claimedWordIndex = index / 256;
+        uint256 claimedBitIndex = index % 256;
+        claimedBitMap[claimedWordIndex] = claimedBitMap[claimedWordIndex] | (1 << claimedBitIndex);
+    }
+
+    function claim(uint256 index, address account, uint256 amount, bytes32[] calldata merkleProof) external override {
+        require(!isClaimed(index), 'MerkleDistributor: Drop already claimed.');
+
+        // Verify the merkle proof.
+        bytes32 node = keccak256(abi.encodePacked(index, account, amount));
+        require(MerkleProof.verify(merkleProof, merkleRoot, node), 'MerkleDistributor: Invalid proof.');
+
+        // Mark it claimed and send the token.
+        _setClaimed(index);
+        require(IERC20(token).transfer(account, amount), 'MerkleDistributor: Transfer failed.');
+
+        emit Claimed(index, account, amount);
+    }
+}
+
 /*
 The MIT License (MIT)
 Copyright (c) 2018 Murray Software, LLC.
@@ -976,14 +1134,18 @@ contract CloneFactory {
 contract GovernanceFactory is CloneFactory {
     address public timeLockTemplate;
     address public governorAlphaTemplate;
-    
+    address public merkelDistributerTemplate;
+
     event DeployGovernance(address indexed token, address indexed timelock, address indexed governor);
-    
-    constructor(address _timeLockTemplate, address _governorAlphaTemplate) public {
+    event DeployGovernanceMerkle(address indexed token, address indexed timelock, address indexed governor, address indexed distributer);
+
+    constructor(address _timeLockTemplate, address _governorAlphaTemplate, address _merkelDistributerTemplate) public {
         timeLockTemplate = _timeLockTemplate;
         governorAlphaTemplate = _governorAlphaTemplate;
+        merkelDistributerTemplate = _merkelDistributerTemplate;
+
     }
-    
+
     function deployGovernance(address admin, string calldata _name, string calldata _symbol, uint _totalSupply, uint timeLockDelay, uint _quorumVotes, uint _proposalThreshold, uint _votingPeriod) external {
         /// @dev Initialize governance token.
         GovernanceToken token = new GovernanceToken(admin, _name, _symbol, _totalSupply);
@@ -993,14 +1155,33 @@ contract GovernanceFactory is CloneFactory {
         address governor = initGovernor(timelock, address(token), admin, _name, _quorumVotes, _proposalThreshold, _votingPeriod);
         emit DeployGovernance(address(token), timelock, governor);
     }
-    
+
+    function deployGovernanceWithMerkle(address admin, string calldata _name, string calldata _symbol, uint _totalSupply, uint timeLockDelay, uint _quorumVotes, uint _proposalThreshold, uint _votingPeriod, uint _airdropSupply, bytes32 merkleRoot_) external {
+
+        /// @dev Initialize governance token.
+        GovernanceToken token = new GovernanceToken(admin, _name, _symbol, _totalSupply);
+        /// @dev Initialize timelock clone.
+        address timelock = initTimeLock(admin, timeLockDelay);
+        /// @dev Initialize governor clone.
+        address governor = initGovernor(timelock, address(token), admin, _name, _quorumVotes, _proposalThreshold, _votingPeriod);
+
+        address distributer = initMerkleDistributer(address(token), merkleRoot_);
+
+        emit DeployGovernanceMerkle(address(token), timelock, governor, distributer);
+    }
+
     function initTimeLock(address admin, uint timeLockDelay) private returns (address payable timelock) {
         timelock = address(createClone(timeLockTemplate));
         Timelock(timelock).init(admin, timeLockDelay);
     }
-    
+
     function initGovernor(address timelock, address token, address admin, string memory _name, uint _quorumVotes, uint _proposalThreshold, uint _votingPeriod) private returns (address governor) {
         governor = address(GovernorAlpha(createClone(governorAlphaTemplate)));
         GovernorAlpha(governor).init(timelock, token, admin, _name, _quorumVotes, _proposalThreshold, _votingPeriod);
+    }
+
+    function initMerkleDistributer(address _token, bytes32 merkleRoot_) private returns (address merkleDistributer){
+      merkleDistributer = address(createClone(merkelDistributerTemplate));
+      MerkleDistributor(merkleDistributer).init(_token, merkleRoot_);
     }
 }


### PR DESCRIPTION
add merkle distributer, another deploy function, `deployGovernanceWithMerkle()`, so users have the option to use merkle or not
todo: use `_airdropSupply` in distributer 

related: #2 